### PR TITLE
Change all transforms to operate on the full light set

### DIFF
--- a/pilight/home/views.py
+++ b/pilight/home/views.py
@@ -66,7 +66,7 @@ def bootstrap_client(request):
     tool_color = Color(0.0, 0.0, 0.0)
     base_colors = []
     for light in current_lights:
-        tool_color += light.color or Color(1.0, 1.0, 1.0)
+        tool_color += light.color or Color.get_default()
         base_colors.append(light.color.safe_dict())
     tool_color /= len(current_lights)
 

--- a/pilight/pilight/classes.py
+++ b/pilight/pilight/classes.py
@@ -106,7 +106,7 @@ class Color(object):
 
     @staticmethod
     def get_default():
-        return Color(1.0, 1.0, 1.0)
+        return Color(1.0, 1.0, 1.0, 1.0)
 
     # Blending operations
     @staticmethod
@@ -149,17 +149,14 @@ class Color(object):
         if getattr(a, 'a', 1.0) == 1.0 and getattr(b, 'a', 1.0) == 1.0:
             return Color(a.r * b.r, a.g * b.g, a.b * b.b)
         else:
-            return a.flatten_alpha() * b.flatten_alpha()
+            return Color.blend_mult(a.flatten_alpha(), b.flatten_alpha())
 
     # Operators
     def __add__(self, other):
-        if isinstance(other, Color):
-            if getattr(self, 'a', 1.0) == 1.0 and getattr(other, 'a', 1.0) == 1.0:
-                return Color(self.r + other.r, self.g + other.g, self.b + other.b)
-            else:
-                return self.flatten_alpha() + other.flatten_alpha()
+        if getattr(self, 'a', 1.0) == 1.0 and getattr(other, 'a', 1.0) == 1.0:
+            return Color(self.r + other.r, self.g + other.g, self.b + other.b)
         else:
-            return NotImplemented
+            return self.flatten_alpha() + other.flatten_alpha()
 
     def __mul__(self, other):
         # Don't multiply the alpha
@@ -169,18 +166,11 @@ class Color(object):
         return self * other
 
     def __div__(self, other):
-        if isinstance(other, (int, long, float)):
-            return Color(self.r / other, self.g / other, self.b / other, getattr(self, 'a', 1.0))
-        else:
-            return NotImplemented
-
-    # Operations
-    def scale(self, scale):
-        return Color(self.r * scale, self.g * scale, self.b * scale)
+        return Color(self.r / other, self.g / other, self.b / other, getattr(self, 'a', 1.0))
 
     # Clone
     def clone(self):
-        return Color(self.r, self.g, self.b)
+        return Color(self.r, self.g, self.b, self.a)
 
     # Utility functions
     def safe_r(self):

--- a/pilight/pilight/driver.py
+++ b/pilight/pilight/driver.py
@@ -32,7 +32,8 @@ class LightDriver(object):
 
         self.device = DEVICES[settings.LIGHTS_DEVICE](settings.LIGHTS_NUM_LEDS, settings.LIGHTS_SCALE)
 
-    def pop_message(self):
+    @staticmethod
+    def pop_message():
         """
         Grabs the latest message from Pika, if one is waiting
         Returns the body of the message if present, otherwise None
@@ -245,8 +246,7 @@ class LightDriver(object):
         return result
 
     def do_step(self, start_colors, elapsed_time, transforms, variables):
-        colors = start_colors
-        next_colors = []
+        colors = [color.clone() for color in start_colors]
 
         # Update variables
         for variable in variables.itervalues():
@@ -262,14 +262,8 @@ class LightDriver(object):
             # Tick the transform frame
             transform.tick_frame(elapsed_time, len(colors), external_color)
 
-            # Transform each light
-            for i in range(len(colors)):
-                color = transform.transform(elapsed_time, i, len(colors), colors[i], colors)
-                next_colors.append(color)
-
-            # Save lights for next transform
-            colors = next_colors
-            next_colors = []
+            # Run the transform
+            colors = transform.transform(elapsed_time, colors)
 
         return colors
 

--- a/pilight/pilight/light/transforms.py
+++ b/pilight/pilight/light/transforms.py
@@ -5,7 +5,6 @@ from pilight.classes import Color
 
 
 class TransformBase(object):
-
     def __init__(self, transforminstance):
         # Base classes should override this - and do something with params if need be
         self.transforminstance = transforminstance
@@ -15,9 +14,10 @@ class TransformBase(object):
             self.params = {}
         self.color_channel = None
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         """
         Performs the actual color transformation for this transform step
+        :var list[pilight.classes.Color] input_colors:
         """
         pass
 
@@ -58,26 +58,31 @@ class LayerBase(TransformBase):
         self.opacity = self.params['opacity']
         self.blend_mode = self.params['blend_mode']
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         """
         Performs blending of the layer's color with the existing color in
         the given position, using opacity and blending modes. Should not be
-        overriden by inherited classes - override get_color instead.
+        overridden by inherited classes - override get_color instead.
         """
-        # Grab the color from the layer and apply the opacity
-        color = self.get_color(time, position, num_positions)
-        color.a *= self.opacity
 
-        # Perform blending with the given blend mode
-        # Currently support "multiply" and "normal" modes - normal being the default
-        # if an unknown mode gets passed in
-        if self.blend_mode == 'multiply':
-            # TODO: Actually implement multiplicative blending
-            result = Color.blend_mult(start_color, color)
-        else:
-            result = Color.blend_normal(start_color, color)
+        total = len(input_colors)
+        for index, input_color in enumerate(input_colors):
+            # Grab the color from the layer and apply the opacity
+            color = self.get_color(time, index, total)
+            color.a *= self.opacity
 
-        return result
+            # Perform blending with the given blend mode
+            # Currently support "multiply" and "normal" modes - normal being the default
+            # if an unknown mode gets passed in
+            if self.blend_mode == 'multiply':
+                # TODO: Actually implement multiplicative blending
+                color = Color.blend_mult(input_color, color)
+            else:
+                color = Color.blend_normal(input_color, color)
+
+            input_colors[index] = color
+
+        return input_colors
 
     def get_color(self, time, position, num_positions):
         """
@@ -88,7 +93,6 @@ class LayerBase(TransformBase):
 
 
 class ExternalColorLayer(LayerBase):
-
     def __init__(self, transforminstance):
         super(ExternalColorLayer, self).__init__(transforminstance)
 
@@ -104,7 +108,6 @@ class ExternalColorLayer(LayerBase):
 
 
 class ExternalColorBurstLayer(LayerBase):
-
     def __init__(self, transforminstance):
         super(ExternalColorBurstLayer, self).__init__(transforminstance)
 
@@ -133,7 +136,7 @@ class ExternalColorBurstLayer(LayerBase):
 
         # Spawn new sparks
         for i in range(num_positions):
-            if random.random() < chance and not i in self.sparks.keys():
+            if random.random() < chance and i not in self.sparks.keys():
                 self.sparks[i] = 0
 
         # Determine brightnesses
@@ -159,8 +162,7 @@ class ExternalColorBurstLayer(LayerBase):
 
 
 class ColorFlashTransform(TransformBase):
-
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         # Transform time/rate into a percentage for the current oscillation
         length = self.params['length']
         progress = float(time) / float(length) - int(time / length)
@@ -182,12 +184,14 @@ class ColorFlashTransform(TransformBase):
         # Compute value based on progress and start/end vals
         mult_color = flash_start_color * (1 - progress) + flash_end_color * progress
 
-        return start_color * mult_color
+        for index, color in enumerate(input_colors):
+            input_colors[index] = Color.blend_mult(color, mult_color)
+
+        return input_colors
 
 
 class FlashTransform(TransformBase):
-
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         # Transform time/rate into a percentage for the current oscillation
         length = self.params['length']
         progress = float(time) / float(length) - int(time / length)
@@ -205,11 +209,13 @@ class FlashTransform(TransformBase):
         # Compute value based on progress and start/end vals
         scale = (1 - progress) * self.params['start_value'] + progress * self.params['end_value']
 
-        return start_color.scale(scale)
+        for index in range(len(input_colors)):
+            input_colors[index] *= scale
+
+        return input_colors
 
 
 class StrobeTransform(TransformBase):
-
     def __init__(self, transforminstance):
         super(StrobeTransform, self).__init__(transforminstance)
 
@@ -227,90 +233,98 @@ class StrobeTransform(TransformBase):
                 self.state_on = True
                 self.frames = 0
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         if self.state_on:
-            return start_color
+            return input_colors
         else:
-            return Color(0, 0, 0)
+            return [Color(0, 0, 0)] * len(input_colors)
 
 
 class ScrollTransform(TransformBase):
+    def transform(self, time, input_colors):
+        total = len(input_colors)
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
         # Transform time/rate into a percentage
         length = self.params['length']
         progress = float(time) / float(length) - int(time / length)
 
         # Calculate offset to source from
-        offset = progress * num_positions
-        source_position = (int(offset) + position) % num_positions
-        next_position = (source_position + 1) % num_positions
-        percent = offset % 1
+        offset = progress * total
 
-        # Compute the blended color
-        if percent == 0 or not self.params['blend']:
-            return all_colors[source_position].clone()
-        else:
-            return all_colors[source_position] * (1 - percent) + all_colors[next_position] * percent
+        colors = []
+        for index, input_color in enumerate(input_colors):
+            source_position = (int(offset) + index) % total
+            percent = offset % 1
+
+            if percent == 0 or not self.params['blend']:
+                colors.append(input_colors[source_position])
+                continue
+
+            next_position = (source_position + 1) % total
+            colors.append(input_colors[source_position] * (1 - percent) + input_colors[next_position] * percent)
+
+        return colors
 
 
 class RotateHueTransform(TransformBase):
-
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         # Transform time/rate into a percentage
         length = self.params['length']
         progress = float(time) / float(length) - int(time / length)
 
-        # Get color as HSV
-        h, s, v, a = start_color.to_hsv()
+        for index, input_color in enumerate(input_colors):
+            # Get color as HSV
+            h, s, v, a = input_color.to_hsv()
 
-        # Rotate H by given amount
-        h = (h + progress * 360) % 360
+            # Rotate H by given amount
+            h = (h + progress * 360) % 360
 
-        # Transform HSV back to RGB and return
-        return Color.from_hsv(h, s, v, a)
+            # Transform HSV back to RGB and return
+            input_colors[index] = Color.from_hsv(h, s, v, a)
+
+        return input_colors
 
 
 class GaussianBlurTransform(TransformBase):
-
     def is_animated(self):
         return False
 
-    def gaussian(self, x, sd):
+    @staticmethod
+    def gaussian(x, sd):
         sd = float(sd)
         x = float(x)
         return (1 / (math.sqrt(2 * math.pi) * sd)) * math.exp(-1 * x * x / (2 * sd * sd))
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         # Algorithm here:
         # http://homepages.inf.ed.ac.uk/rbf/HIPR2/gsmooth.htm (1-D case)
         sd = self.params['standarddev']
 
         radius = int(sd * 3)
-        min_position = position - radius
-        max_position = position + radius
-
         # Because the Gaussian distribution is asymptotic, if we use the
         # raw values then the integral will be <1 - thus we want to
         # grab the total and scale by the inverse of that amount
         gaussians = {}
         total = 0
-        for i in range(-radius, radius):
-            gaussians[i] = self.gaussian(i, sd)
-            total += gaussians[i]
+        for offset in range(-radius, radius):
+            gaussians[offset] = self.gaussian(offset, sd)
+            total += gaussians[offset]
 
-        # Build the new color
-        result = Color(0, 0, 0)
+        colors = []
+        num_colors = len(input_colors)
+        for index in range(len(input_colors)):
+            color = Color(0.0, 0.0, 0.0)
 
-        for i in range(min_position, max_position):
-            current_position = i % num_positions
-            result += all_colors[current_position] * (gaussians[i - position] / total)
+            for offset in range(-radius, radius):
+                current_position = (offset + index) % num_colors
+                color += input_colors[current_position] * (gaussians[offset] / total)
 
-        return result
+            colors.append(color)
+
+        return colors
 
 
 class BurstTransform(TransformBase):
-
     def __init__(self, transforminstance):
         super(BurstTransform, self).__init__(transforminstance)
 
@@ -325,7 +339,7 @@ class BurstTransform(TransformBase):
         # Advance existing sparks
         elapsed_time = time - self.last_time
         for i in self.sparks.keys():
-            self.sparks[i] += elapsed_time / self.params['burst_length']
+            self.sparks[i] += elapsed_time / float(self.params['burst_length'])
             if self.sparks[i] >= 1:
                 del self.sparks[i]
 
@@ -334,33 +348,31 @@ class BurstTransform(TransformBase):
 
         # Spawn new sparks
         for i in range(num_positions):
-            if random.random() < chance and not i in self.sparks.keys():
+            if random.random() < chance and i not in self.sparks.keys():
                 self.sparks[i] = 0
 
         # Determine brightnesses
-        self.brightnesses = [0] * num_positions
-        radius = self.params['burst_radius']
+        self.brightnesses = [0.0] * num_positions
+        radius = int(self.params['burst_radius'])
         for index, progress in self.sparks.iteritems():
-            spark_strength = 1 - abs((progress - 0.5) * 2)
-            min_index = int(max(0, index - radius))
-            max_index = int(min(num_positions, index + radius + 1))
-            for i in range(min_index, max_index):
-                distance = abs(index - i)
+            spark_strength = 1.0 - abs((progress - 0.5) * 2)
+
+            for offset in range(-radius, radius + 1):
                 # TODO: Better falloff function
-                self.brightnesses[i] += (1.0 - (float(distance) / radius)) * spark_strength
+                position = (index + offset) % num_positions
+                self.brightnesses[position] += (1.0 - (float(abs(offset)) / float(radius))) * spark_strength
 
         # Save this time for the next iteration
         self.last_time = time
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         # Apply the saved brightnesses
-        result = start_color.clone()
-        result.a *= self.brightnesses[position]
-        return result
+        for index in range(len(input_colors)):
+            input_colors[index] *= self.brightnesses[index]
+        return input_colors
 
 
 class NoiseTransform(TransformBase):
-
     def __init__(self, transforminstance):
         super(NoiseTransform, self).__init__(transforminstance)
 
@@ -369,7 +381,8 @@ class NoiseTransform(TransformBase):
         self.current_colors = []
         self.next_colors = []
 
-    def get_random_colors(self, length):
+    @staticmethod
+    def get_random_colors(length):
         colors = []
         for i in range(length):
             colors.append(Color(random.random(), random.random(), random.random()))
@@ -389,30 +402,34 @@ class NoiseTransform(TransformBase):
 
         self.progress = (float(time) - float(self.last_time)) / self.params['length']
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
 
-        tween_color = self.next_colors[position] * self.progress + self.current_colors[position] * (1 - self.progress)
+        for index, color in enumerate(input_colors):
+            tween_color = self.next_colors[index] * self.progress + self.current_colors[index] * (1 - self.progress)
 
-        r_str = self.params['red_strength']
-        g_str = self.params['green_strength']
-        b_str = self.params['blue_strength']
+            r_str = self.params['red_strength']
+            g_str = self.params['green_strength']
+            b_str = self.params['blue_strength']
 
-        return Color(start_color.r * (1 - r_str) + tween_color.r * r_str,
-                     start_color.g * (1 - g_str) + tween_color.g * g_str,
-                     start_color.b * (1 - b_str) + tween_color.b * b_str)
+            input_colors[index] = Color(color.r * (1 - r_str) + tween_color.r * r_str,
+                                        color.g * (1 - g_str) + tween_color.g * g_str,
+                                        color.b * (1 - b_str) + tween_color.b * b_str)
+
+        return input_colors
 
 
 class BrightnessTransform(TransformBase):
-
     def is_animated(self):
         return False
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
-        return start_color * self.params['brightness']
+    def transform(self, time, input_colors):
+        for index in range(len(input_colors)):
+            input_colors[index] *= self.params['brightness']
+
+        return input_colors
 
 
 class BrightnessVariableTransform(TransformBase):
-
     def __init__(self, transforminstance, variable):
         super(BrightnessVariableTransform, self).__init__(transforminstance)
         self.variable = variable
@@ -420,9 +437,14 @@ class BrightnessVariableTransform(TransformBase):
     def is_animated(self):
         return True
 
-    def transform(self, time, position, num_positions, start_color, all_colors):
+    def transform(self, time, input_colors):
         val = self.variable.get_value()
-        return Color(start_color.r * val, min(start_color.g * val, 0.3), min(start_color.b * val, 0.1), start_color.a)
+        for index, color in enumerate(input_colors):
+            input_colors[index] = Color(
+                color.r * val,
+                min(color.g * val, 0.3),
+                min(color.b * val, 0.1),
+                color.a)
 
 
 AVAILABLE_TRANSFORMS = {


### PR DESCRIPTION
Previously, transforms operated pixel by pixel. This changeset tries to improve efficiency by:

- Passing the entire set of pixels into each transform, so they can operate in a single pass and potentially reap performance improvements. (Depends on the individual transform to some extent).
- Allowing transforms to operate on the colors in-place, by cloning the colors in do_step. Should hopefully reduce memory thrashing and thereby improve performance.