### PR TITLE
Add light repeat factor

### DIFF
--- a/pilight/pilight/devices/base.py
+++ b/pilight/pilight/devices/base.py
@@ -4,11 +4,22 @@ import abc
 class DeviceBase(object):
     __metaclass__ = abc.ABCMeta
 
-    @abc.abstractmethod
-    def __init__(self, num_leds, scale):
+    def __init__(self, num_leds, scale, repeat):
         self.num_leds = num_leds
         self.scale = scale
+        self.repeat = repeat
+
+    def show_colors(self, colors):
+        for r in range(self.repeat):
+            for i, color in enumerate(colors):
+                for s in range(self.scale):
+                    self.set_color(r * self.num_leds + i * self.scale + s, color)
+
+        self.finish()
 
     @abc.abstractmethod
-    def set_colors(self, colors):
+    def set_color(self, index, color):
+        pass
+
+    def finish(self):
         pass

--- a/pilight/pilight/devices/client.py
+++ b/pilight/pilight/devices/client.py
@@ -7,11 +7,12 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale):
-        super(Device, self).__init__(num_leds, scale)
+    def __init__(self, num_leds, scale, repeat):
+        super(Device, self).__init__(num_leds, scale, repeat)
         self.messages_since_last_queue_check = 0
 
-    def set_colors(self, colors):
+    # Override the whole show_colors method for this device
+    def show_colors(self, colors):
         """
         Publishes the color data to a Pika queue for ingestion
         by a client - usually pilight-client

--- a/pilight/pilight/devices/noop.py
+++ b/pilight/pilight/devices/noop.py
@@ -2,8 +2,8 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale):
-        super(Device, self).__init__(num_leds, scale)
+    def __init__(self, num_leds, scale, repeat):
+        super(Device, self).__init__(num_leds, scale, repeat)
 
-    def set_colors(self, colors):
+    def set_color(self, index, color):
         pass

--- a/pilight/pilight/devices/ws2801.py
+++ b/pilight/pilight/devices/ws2801.py
@@ -2,21 +2,19 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale):
-        super(Device, self).__init__(num_leds, scale)
+    def __init__(self, num_leds, scale, repeat):
+        super(Device, self).__init__(num_leds, scale, repeat)
 
         import Adafruit_WS2801
         from Adafruit_GPIO import SPI
         self.strip = Adafruit_WS2801.WS2801Pixels(
-            num_leds * scale,
+            num_leds * scale * repeat,
             spi=SPI.SpiDev(0, 0))
         self.strip.clear()
         self.strip.show()
 
-    def set_colors(self, colors):
-        for idx, color in enumerate(colors):
-            out_color = color.to_raw_corrected()
-            for light_num in range(self.scale):
-                self.strip.set_pixel(idx * self.scale + light_num, out_color)
+    def set_color(self, index, color):
+        self.strip.set_pixel(index, color.to_raw_corrected())
 
+    def finish(self):
         self.strip.show()

--- a/pilight/pilight/devices/ws281x.py
+++ b/pilight/pilight/devices/ws281x.py
@@ -4,14 +4,14 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale):
-        super(Device, self).__init__(num_leds, scale)
+    def __init__(self, num_leds, scale, repeat):
+        super(Device, self).__init__(num_leds, scale, repeat)
 
         import neopixel
         strip_type = getattr(neopixel.ws, settings.WS281X_STRIP)
 
         self.strip = neopixel.Adafruit_NeoPixel(
-            num=num_leds * scale,
+            num=num_leds * scale * repeat,
             pin=settings.WS281X_LED_PIN,
             freq_hz=settings.WS281X_FREQ_HZ,
             dma=settings.WS281X_DMA,
@@ -21,15 +21,8 @@ class Device(base.DeviceBase):
             strip_type=strip_type)
         self.strip.begin()
 
-    def set_colors(self, colors):
-        for idx, color in enumerate(colors):
-            out_r = int(color.safe_corrected_r() * 255)
-            out_g = int(color.safe_corrected_g() * 255)
-            out_b = int(color.safe_corrected_b() * 255)
+    def set_color(self, index, color):
+        self.strip.setPixelColorRGB(index, color.to_raw_corrected())
 
-            for light_num in range(self.scale):
-                self.strip.setPixelColorRGB(
-                    idx * self.scale + light_num,
-                    out_r, out_g, out_b)
-
+    def finish(self):
         self.strip.show()

--- a/pilight/pilight/devices/ws281x.py
+++ b/pilight/pilight/devices/ws281x.py
@@ -22,7 +22,7 @@ class Device(base.DeviceBase):
         self.strip.begin()
 
     def set_color(self, index, color):
-        self.strip.setPixelColorRGB(index, color.to_raw_corrected())
+        self.strip.setPixelColor(index, color.to_raw_corrected())
 
     def finish(self):
         self.strip.show()

--- a/pilight/pilight/devices/ws281x.py
+++ b/pilight/pilight/devices/ws281x.py
@@ -22,7 +22,13 @@ class Device(base.DeviceBase):
         self.strip.begin()
 
     def set_color(self, index, color):
-        self.strip.setPixelColor(index, color.to_raw_corrected())
+        if color.a != 1.0:
+            color = color.flatten_alpha()
+
+        r = int(color.safe_corrected_r() * 255)
+        g = int(color.safe_corrected_g() * 255)
+        b = int(color.safe_corrected_b() * 255)
+        self.strip.setPixelColorRGB(index, r, g, b)
 
     def finish(self):
         self.strip.show()

--- a/pilight/pilight/driver.py
+++ b/pilight/pilight/driver.py
@@ -30,7 +30,11 @@ class LightDriver(object):
         if settings.LIGHTS_DEVICE not in DEVICES:
             raise KeyError('Unknown device specified, please check your settings')
 
-        self.device = DEVICES[settings.LIGHTS_DEVICE](settings.LIGHTS_NUM_LEDS, settings.LIGHTS_SCALE)
+        self.device = DEVICES[settings.LIGHTS_DEVICE](
+            settings.LIGHTS_NUM_LEDS,
+            settings.LIGHTS_SCALE,
+            settings.LIGHTS_REPEAT,
+        )
 
     @staticmethod
     def pop_message():
@@ -137,7 +141,7 @@ class LightDriver(object):
             self.start_time = None
 
     def set_colors(self, colors):
-        self.device.set_colors(colors)
+        self.device.show_colors(colors)
 
     def clear_lights(self):
         black = [Color(0, 0, 0)] * settings.LIGHTS_NUM_LEDS

--- a/pilight/pilight/settings.py.default
+++ b/pilight/pilight/settings.py.default
@@ -20,7 +20,8 @@ LIGHTS_DRIVER_DEBUG = False
 LIGHTS_INSTALLATION_NAME = 'PiLight'
 
 # Number of lights in the string
-# The true number of LED data points emitted is NUM_LEDS * SCALE
+# The true number of LED data points emitted is:
+#   NUM_LEDS * SCALE * REPEAT
 LIGHTS_NUM_LEDS = 50
 
 # Scale up the light pattern by the given amount
@@ -29,6 +30,13 @@ LIGHTS_NUM_LEDS = 50
 # more efficient. This is especially useful for large numbers
 # of LEDs
 LIGHTS_SCALE = 1
+
+# Repeat the light pattern a given number of times
+# If this is 1, the pattern is only output once. If larger numbers
+# are used, the pattern is output multiple times, and the
+# calculation becomes more efficient. Useful for large numbers
+# of LEDs.
+LIGHTS_REPEAT = 1
 
 # Require a valid Django user to change the lights?
 # Recommend setting this to True for externally


### PR DESCRIPTION
Lets lights repeat their pattern N times. Similar to scale, this will expand the output, without requiring additional computational overhead for lights and transforms.

This diff also slightly reworks devices to make them a little easier to extend, and centralize the repeat/scale logic.