### PR TITLE
Allow proper ordering of transforms

### DIFF
--- a/pilight/client/Transforms/Picker.jsx
+++ b/pilight/client/Transforms/Picker.jsx
@@ -71,7 +71,7 @@ Picker.propTypes = {
             transform: PropTypes.string.isRequired,
             name: PropTypes.string.isRequired,
             description: PropTypes.string,
-            paramsDef: PropTypes.arrayOf(
+            paramsDef: PropTypes.objectOf(
                 PropTypes.shape({
                     type: PropTypes.string.isRequired,
                     name: PropTypes.string,

--- a/pilight/client/Transforms/Transform.jsx
+++ b/pilight/client/Transforms/Transform.jsx
@@ -1,0 +1,66 @@
+import React, {PropTypes} from 'react';
+import {
+    Button,
+    ButtonGroup,
+    Table,
+} from 'react-bootstrap';
+
+import {ParamEditor} from './ParamEditor';
+
+import css from './Transform.scss';
+
+
+class Transform extends React.Component {
+    render() {
+        return (
+            <Table bordered striped>
+                <thead>
+                    <tr>
+                        <th colSpan={2}>
+                            {this.props.transform.name}
+                            <div className={css.buttons}>
+                                <ButtonGroup>
+                                    <Button onClick={this.props.moveUp} bsSize="xsmall">Up</Button>
+                                    <Button onClick={this.props.moveDown} bsSize="xsmall">Down</Button>
+                                </ButtonGroup>
+                                {' '}
+                                <Button
+                                    bsStyle="danger"
+                                    bsSize="xsmall"
+                                    onClick={this.props.onDelete}
+                                >Delete</Button>
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Params</td>
+                        <td>
+                            <ParamEditor
+                                onSave={this.props.onSave}
+                                value={this.props.transform.params}
+                            />
+                        </td>
+                    </tr>
+                </tbody>
+            </Table>
+        )
+    }
+}
+
+Transform.propTypes = {
+    transform: PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        transform: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
+        params: PropTypes.any,
+    }).isRequired,
+    description: PropTypes.string,
+    moveDown: PropTypes.func.isRequired,
+    moveUp: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onDelete: PropTypes.func.isRequired,
+};
+
+export {Transform};

--- a/pilight/client/Transforms/Transform.scss
+++ b/pilight/client/Transforms/Transform.scss
@@ -1,0 +1,4 @@
+.buttons {
+  display: inline-block;
+  float: right;
+}

--- a/pilight/client/store/client.js
+++ b/pilight/client/store/client.js
@@ -30,7 +30,7 @@ export const saveConfigAsync = (configName) => (dispatch) => {
 };
 
 export const loadConfigAsync = (id) => (dispatch) => {
-    // The response from the server takes a second, so we immediate display loading
+    // The response from the server takes a second, so we immediately display loading
     // to make it feel snappy
     dispatch(startBootstrap());
 

--- a/pilight/client/store/lights.js
+++ b/pilight/client/store/lights.js
@@ -1,6 +1,6 @@
 import {createAction, handleActions} from 'redux-actions';
 
-import {fetchObjectPromise, postObjectPromise} from './async';
+import {postObjectPromise} from './async';
 import {setError} from './client';
 
 
@@ -12,16 +12,7 @@ const clearPreview = createAction(CLEAR_PREVIEW);
 export const setBaseColors = createAction(SET_BASE_COLORS);
 const setPreviewFrame = createAction(SET_PREVIEW_FRAME);
 
-export const getBaseColorsAsync = () => (dispatch) => {
-    return fetchObjectPromise(
-        `/api/light/base-colors/`,
-        (data) => {
-            dispatch(setBaseColors(data.baseColors));
-        },
-        (error) => { dispatch(setError(error)); },
-    );
-};
-
+const PREVIEW_FRAME_TIME = 50;
 function nextFrame(frames, dispatch) { return () => {
     if (frames.length === 0) {
         dispatch(clearPreview());
@@ -32,7 +23,6 @@ function nextFrame(frames, dispatch) { return () => {
     setTimeout(nextFrame(frames, dispatch), PREVIEW_FRAME_TIME);
 }}
 
-const PREVIEW_FRAME_TIME = 50;
 export const doPreviewAsync = () => (dispatch) => {
     return postObjectPromise(
         `/api/light/preview/`,

--- a/pilight/client/store/transforms.js
+++ b/pilight/client/store/transforms.js
@@ -48,6 +48,50 @@ export const updateTransformAsync = ({id, params}) => (dispatch) => {
     );
 };
 
+export const moveTransformDownAsync = (id) => (dispatch, getState) => {
+    const {transforms} = getState();
+
+    // Figure out new order
+    const ids = transforms.active.map((transform) => transform.id);
+    const index = ids.findIndex((transformId) => transformId === id);
+    if (index === -1 || index === ids.length - 1) {
+        // No order change - item is not found, or already bottom
+        return;
+    }
+    ids[index] = ids[index + 1];
+    ids[index + 1] = id;
+
+    postOrder(ids, dispatch);
+};
+
+export const moveTransformUpAsync = (id) => (dispatch, getState) => {
+    const {transforms} = getState();
+
+    // Figure out new order
+    const ids = transforms.active.map((transform) => transform.id);
+    const index = ids.findIndex((transformId) => transformId === id);
+    if (index <= 0) {
+        // No order change - item is not found, or already top
+        return;
+    }
+    ids[index] = ids[index - 1];
+    ids[index - 1] = id;
+
+    postOrder(ids, dispatch);
+};
+
+function postOrder(ids, dispatch) {
+    return postObjectPromise(
+        `/api/transform/reorder/`,
+        {order: ids},
+        (data) => {
+            dispatch(setActiveTransforms(data.activeTransforms));
+        },
+        (error) => { dispatch(setError(error)); },
+    );
+}
+
+
 const INITIAL_STATE = {
     available: [],
     active: [],

--- a/pilight/home/client_queries.py
+++ b/pilight/home/client_queries.py
@@ -19,6 +19,7 @@ def active_transforms():
             'transform': transform_instance.transform,
             'name': transform.name,
             'params': json.loads(transform_instance.params),
+            'order': transform_instance.order,
         })
     return result
 

--- a/pilight/pilight/urls.py
+++ b/pilight/pilight/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     url(r'^api/transform/add/?$', views.add_transform, name='add_transform'),
     url(r'^api/transform/delete/?$', views.delete_transform, name='delete_transform'),
     url(r'^api/transform/update/?$', views.update_transform, name='update_transform'),
+    url(r'^api/transform/reorder/?$', views.reorder_transforms, name='reorder_transforms'),
     url(r'^api/config/load/?$', views.load_config, name='load_config'),
     url(r'^api/config/save/?$', views.save_config, name='save_config'),
     url(r'^api/channel/set/?$', views.update_color_channel, name='update_color_channel'),


### PR DESCRIPTION
Reworks active transforms so that they appear in their own components (instead of in a single table), and allow explicitly reordering them. The components make a logical extension point for allowing individual param edits in future.