### PR TITLE
Use separate process for sending colors to the device

### DIFF
--- a/pilight/pilight/devices/base.py
+++ b/pilight/pilight/devices/base.py
@@ -1,13 +1,35 @@
 import abc
+import multiprocessing
 
 
-class DeviceBase(object):
+class DeviceBase(multiprocessing.Process):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, num_leds, scale, repeat):
+    def __init__(self, colors_pipe, num_leds, scale, repeat):
+        super(DeviceBase, self).__init__()
+
+        self.strip = None
+        self.colors_pipe = colors_pipe
         self.num_leds = num_leds
         self.scale = scale
         self.repeat = repeat
+
+    @abc.abstractmethod
+    def init(self):
+        pass
+
+    def run(self):
+        self.init()
+        try:
+            while True:
+                colors = self.colors_pipe.recv()
+                if not colors:
+                    return
+
+                self.show_colors(colors)
+
+        except KeyboardInterrupt:
+            return
 
     def show_colors(self, colors):
         for r in range(self.repeat):

--- a/pilight/pilight/devices/client.py
+++ b/pilight/pilight/devices/client.py
@@ -7,9 +7,12 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale, repeat):
-        super(Device, self).__init__(num_leds, scale, repeat)
+    def __init__(self, colors_pipe, num_leds, scale, repeat):
+        super(Device, self).__init__(colors_pipe, num_leds, scale, repeat)
         self.messages_since_last_queue_check = 0
+
+    def init(self):
+        pass
 
     # Override the whole show_colors method for this device
     def show_colors(self, colors):

--- a/pilight/pilight/devices/noop.py
+++ b/pilight/pilight/devices/noop.py
@@ -2,8 +2,8 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale, repeat):
-        super(Device, self).__init__(num_leds, scale, repeat)
+    def init(self):
+        pass
 
     def set_color(self, index, color):
         pass

--- a/pilight/pilight/devices/ws2801.py
+++ b/pilight/pilight/devices/ws2801.py
@@ -2,13 +2,11 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale, repeat):
-        super(Device, self).__init__(num_leds, scale, repeat)
-
+    def init(self):
         import Adafruit_WS2801
         from Adafruit_GPIO import SPI
         self.strip = Adafruit_WS2801.WS2801Pixels(
-            num_leds * scale * repeat,
+            self.num_leds * self.scale * self.repeat,
             spi=SPI.SpiDev(0, 0))
         self.strip.clear()
         self.strip.show()

--- a/pilight/pilight/devices/ws281x.py
+++ b/pilight/pilight/devices/ws281x.py
@@ -4,14 +4,12 @@ from pilight.devices import base
 
 
 class Device(base.DeviceBase):
-    def __init__(self, num_leds, scale, repeat):
-        super(Device, self).__init__(num_leds, scale, repeat)
-
+    def init(self):
         import neopixel
         strip_type = getattr(neopixel.ws, settings.WS281X_STRIP)
 
         self.strip = neopixel.Adafruit_NeoPixel(
-            num=num_leds * scale * repeat,
+            num=self.num_leds * self.scale * self.repeat,
             pin=settings.WS281X_LED_PIN,
             freq_hz=settings.WS281X_FREQ_HZ,
             dma=settings.WS281X_DMA,

--- a/pilight/pilight/driver.py
+++ b/pilight/pilight/driver.py
@@ -219,7 +219,7 @@ class LightDriver(object):
 
     def set_colors(self, colors):
         """Passes the given colors down to the output device for display."""
-        threading.Thread(target=self.device.show_colors, kwargs={colors: colors}).start()
+        threading.Thread(target=self.device.show_colors, kwargs={'colors': colors}).start()
 
     def clear_lights(self):
         """Sets all of the lights to black. Useful when exiting."""

--- a/pilight/pilight/driver.py
+++ b/pilight/pilight/driver.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import threading
 import time
 
@@ -34,11 +35,16 @@ class LightDriver(object):
         if settings.LIGHTS_DEVICE not in DEVICES:
             raise KeyError('Unknown device specified, please check your settings')
 
+        colors_recv, colors_send = multiprocessing.Pipe(duplex=False)
+        self.colors_pipe = colors_send
+
         self.device = DEVICES[settings.LIGHTS_DEVICE](
+            colors_recv,
             settings.LIGHTS_NUM_LEDS,
             settings.LIGHTS_SCALE,
             settings.LIGHTS_REPEAT,
         )
+        self.device.start()
 
     def wait(self):
         """
@@ -219,7 +225,7 @@ class LightDriver(object):
 
     def set_colors(self, colors):
         """Passes the given colors down to the output device for display."""
-        threading.Thread(target=self.device.show_colors, kwargs={'colors': colors}).start()
+        self.colors_pipe.send(colors)
 
     def clear_lights(self):
         """Sets all of the lights to black. Useful when exiting."""

--- a/pilight/pilight/driver.py
+++ b/pilight/pilight/driver.py
@@ -1,3 +1,4 @@
+import threading
 import time
 
 from django.conf import settings
@@ -218,7 +219,7 @@ class LightDriver(object):
 
     def set_colors(self, colors):
         """Passes the given colors down to the output device for display."""
-        self.device.show_colors(colors)
+        threading.Thread(target=self.device.show_colors, kwargs={colors: colors}).start()
 
     def clear_lights(self):
         """Sets all of the lights to black. Useful when exiting."""


### PR DESCRIPTION
Use the multiprocessing lib again to offload some processing to another thread and better utilize multiple cores on a Raspberry Pi. On the Pi 3 (with 4 cores), this gave a performance increase of approx 70%! Now getting 33+ FPS with audio and some basic transforms (WS281x).