### PR TITLE
Add fast blur transform as a replacement for Gaussian blur

### DIFF
--- a/pilight/pilight/classes.py
+++ b/pilight/pilight/classes.py
@@ -167,6 +167,17 @@ class Color(object):
         else:
             return self.flatten_alpha() + other.flatten_alpha()
 
+    def __sub__(self, other):
+        if getattr(self, 'a', 1.0) == 1.0 and getattr(other, 'a', 1.0) == 1.0:
+            return Color(
+                self.r - other.r,
+                self.g - other.g,
+                self.b - other.b,
+                getattr(self, 'w', 0.0) - getattr(other, 'w', 0.0),
+            )
+        else:
+            return self.flatten_alpha() - other.flatten_alpha()
+
     def __mul__(self, other):
         # Don't multiply the alpha
         return Color(

--- a/pilight/pilight/driver.py
+++ b/pilight/pilight/driver.py
@@ -211,6 +211,8 @@ class LightDriver(object):
         if not current_colors:
             return None
 
+        print len(current_colors)
+
         result = []
 
         for i in range(steps):

--- a/pilight/pilight/driver.py
+++ b/pilight/pilight/driver.py
@@ -211,8 +211,6 @@ class LightDriver(object):
         if not current_colors:
             return None
 
-        print len(current_colors)
-
         result = []
 
         for i in range(steps):

--- a/pilight/pilight/light/transforms.py
+++ b/pilight/pilight/light/transforms.py
@@ -390,9 +390,11 @@ class FastBlur(TransformBase):
     def tick_frame(self, time, num_positions):
         self.boxes = self.boxes_for_gauss(self.params.standarddev, self.params.passes)
 
-    # Adapted from: http://blog.ivank.net/fastest-gaussian-blur.html
+    # Adapted from:
+    #   http://blog.ivank.net/fastest-gaussian-blur.html
+    #   http://elynxsdk.free.fr/ext-docs/Blur/Fast_box_blur.pdf
+    # Performs several box filter passes to approximate a Gaussian blur
     def transform(self, time, input_colors):
-        # source channel, target channel, width, height, radius
         result = input_colors
         num_colors = len(result)
 


### PR DESCRIPTION
Blur is a very useful feature, but the true Gaussian blur implementation that was present previously was too slow for practical use. This fast blur implementation can be used without sacrificing as much in the way of framerate. Anecdotally, this is 52% faster for 2 passes, and 35% faster for 3 passes.