### PR TITLE
Ratelimit Spectrum Flow to not update more frequently than the interval between two lights

### DIFF
--- a/pilight/pilight/light/transforms.py
+++ b/pilight/pilight/light/transforms.py
@@ -787,8 +787,8 @@ class SpectrumFlowLayer(LayerBase):
             self.colors.pop()
 
         # Don't update more frequently than the "interval" between two lights
-        min_update_time = self.params.duration / settings.LIGHTS_NUM_LEDS
-        if time - self.last_time < min_update_time:
+        min_update_time = float(self.params.duration) / settings.LIGHTS_NUM_LEDS
+        if len(self.colors) > 0 and time - self.last_time < min_update_time:
             return
 
         # Compute spectrum color

--- a/pilight/pilight/light/transforms.py
+++ b/pilight/pilight/light/transforms.py
@@ -3,6 +3,8 @@ import json
 import math
 import random
 
+from django.conf import settings
+
 from home.models import load_variable_params
 from pilight.classes import Color
 from pilight.light.params import BooleanParam, LongParam, FloatParam, PercentParam, \
@@ -775,6 +777,7 @@ class SpectrumFlowLayer(LayerBase):
         super(SpectrumFlowLayer, self).__init__(transform_instance, variables)
         self.colors = collections.deque()
         self.display_colors = []
+        self.last_time = 0
 
     def tick_frame(self, time, num_positions):
         duration = self.params.duration
@@ -782,6 +785,11 @@ class SpectrumFlowLayer(LayerBase):
         # Drop colors that are no longer relevant - look ahead by one
         while len(self.colors) > 1 and time - self.colors[1].time > duration:
             self.colors.pop()
+
+        # Don't update more frequently than the "interval" between two lights
+        min_update_time = self.params.duration / settings.LIGHTS_NUM_LEDS
+        if time - self.last_time < min_update_time:
+            return
 
         # Compute spectrum color
         value = min(1.0, max(0.0, self.params.value))
@@ -796,6 +804,7 @@ class SpectrumFlowLayer(LayerBase):
             time=time,
             color=color,
         ))
+        self.last_time = time
 
     def get_colors(self, time, num_positions):
         if len(self.colors) == 1:


### PR DESCRIPTION
Spectrum Flow was giving flickery behavior, due to the way it interpolates colors across lights - specifically, if the value was being update more frequently than the interval between two lights. This causes some values to be skipped intermittently, so a brief bright value can cause flickering down the strip. This naive solution just skips producing new colors if the interval is too short.