### PR TITLE
Add MPC3008 ADC support

### DIFF
--- a/pilight/pilight/light/variables.py
+++ b/pilight/pilight/light/variables.py
@@ -100,7 +100,8 @@ class AnalogVariable(Variable):
         min_raw = float(self.params.min_raw)
         max_raw = float(self.params.max_raw)
 
-        self.val = min(1.0, max(0.0, float(adc.read_adc(self.params.channel) - min_raw) / (max_raw - min_raw)))
+        adc_val = float(adc.read_adc(int(self.params.channel)))
+        self.val = min(1.0, max(0.0, (adc_val - min_raw) / (max_raw - min_raw)))
 
     def get_value(self):
         if not settings.ENABLE_ADC:

--- a/pilight/pilight/settings.py.default
+++ b/pilight/pilight/settings.py.default
@@ -78,6 +78,10 @@ LIGHTS_MULTIPLIER_W = 0.5
 # Set to True to enable the audio variable based on mic level
 ENABLE_AUDIO_VAR = False
 
+# Set to True to enable the MPC3008 ADC variable
+ENABLE_ADC = True
+
+
 #################
 # WS2801 settings
 


### PR DESCRIPTION
Allows hooking up analog inputs such as switches and pots, by piping them through a variable. Basic hardcoded implementation for now - should probably be extended for additional ICs in future.